### PR TITLE
Add Fabric Google Places (Legacy) geocoding notebook and offline validation script; update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ This project is inspired by the need to understand and mitigate the devastating 
 - Delta table schemas, pipeline orchestration, cache MERGE logic, and optimization steps are unchanged.
 - Use `scripts/validate_places_mappings.py` to score offline mapping quality with no Google API calls. It compares input vs. returned address components, detects city-level/partial matches, optionally checks distance against expected coordinates, enforces the expected NYC + Westchester geographic boundary, and writes record-level flags plus a confidence score.
 - Use `fabric_places_mapping_validation_notebook.py` for a Microsoft Fabric Lakehouse / PySpark implementation that reads Delta tables, writes validation and summary results back to Delta, and runs `OPTIMIZE` / `VACUUM` maintenance in a Fabric-friendly notebook flow.
+- Use `fabric_places_mapping_validation_lightweight_notebook.py` for a cleaner, lighter PySpark/Fabric version that removes broad state-normalization logic, keeps the validator focused on NYC + Westchester assumptions, and centralizes repeated comparison logic.
 
 References:
 - Find Place (Legacy): https://developers.google.com/maps/documentation/places/web-service/legacy/search-find-place

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ This project is inspired by the need to understand and mitigate the devastating 
 - Optional Place Details fallback is supported behind a config flag: `enable_place_details_fallback` (default `False`).
 - Delta table schemas, pipeline orchestration, cache MERGE logic, and optimization steps are unchanged.
 - Use `scripts/validate_places_mappings.py` to score offline mapping quality with no Google API calls. It compares input vs. returned address components, detects city-level/partial matches, optionally checks distance against expected coordinates, enforces the expected NYC + Westchester geographic boundary, and writes record-level flags plus a confidence score.
+- Use `fabric_places_mapping_validation_notebook.py` for a Microsoft Fabric Lakehouse / PySpark implementation that reads Delta tables, writes validation and summary results back to Delta, and runs `OPTIMIZE` / `VACUUM` maintenance in a Fabric-friendly notebook flow.
 
 References:
 - Find Place (Legacy): https://developers.google.com/maps/documentation/places/web-service/legacy/search-find-place

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ This project is inspired by the need to understand and mitigate the devastating 
 - Delta table schemas, pipeline orchestration, cache MERGE logic, and optimization steps are unchanged.
 - Use `scripts/validate_places_mappings.py` to score offline mapping quality with no Google API calls. It compares input vs. returned address components, detects city-level/partial matches, optionally checks distance against expected coordinates, enforces the expected NYC + Westchester geographic boundary, and writes record-level flags plus a confidence score.
 - Use `fabric_places_mapping_validation_notebook.py` for a Microsoft Fabric Lakehouse / PySpark implementation that reads Delta tables, writes validation and summary results back to Delta, and runs `OPTIMIZE` / `VACUUM` maintenance in a Fabric-friendly notebook flow.
-- Use `fabric_places_mapping_validation_lightweight_notebook.py` for a cleaner, lighter PySpark/Fabric version that removes broad state-normalization logic, keeps the validator focused on NYC + Westchester assumptions, and centralizes repeated comparison logic.
+- Use `fabric_places_mapping_validation_lightweight_notebook.py` for a cleaner, lighter PySpark/Fabric version that removes broad state-normalization logic, keeps the validator focused on NYC + Westchester assumptions, centralizes repeated comparison logic, and treats source lat/lng as an informational validation signal rather than a confidence-score input.
 
 References:
 - Find Place (Legacy): https://developers.google.com/maps/documentation/places/web-service/legacy/search-find-place

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ This project is inspired by the need to understand and mitigate the devastating 
 - The Fabric notebook geocoding call layer now uses **Google Places API (Legacy) - Find Place** (`findplacefromtext`) with `inputtype=textquery` and **Basic fields only** (`place_id,formatted_address,geometry,name`) to control field-based billing.
 - Optional Place Details fallback is supported behind a config flag: `enable_place_details_fallback` (default `False`).
 - Delta table schemas, pipeline orchestration, cache MERGE logic, and optimization steps are unchanged.
-- Use `scripts/validate_places_mappings.py` to score offline mapping quality with no Google API calls. It compares input vs. returned address components, detects city-level/partial matches, optionally checks distance against expected coordinates, and writes record-level flags plus a confidence score.
+- Use `scripts/validate_places_mappings.py` to score offline mapping quality with no Google API calls. It compares input vs. returned address components, detects city-level/partial matches, optionally checks distance against expected coordinates, enforces the expected NYC + Westchester geographic boundary, and writes record-level flags plus a confidence score.
 
 References:
 - Find Place (Legacy): https://developers.google.com/maps/documentation/places/web-service/legacy/search-find-place

--- a/README.md
+++ b/README.md
@@ -109,3 +109,18 @@ This project is inspired by the need to understand and mitigate the devastating 
 ## **Connect with Me**
 - LinkedIn: [my LinkedIn](https://www.linkedin.com/in/nikhil-racha/)
 
+
+---
+
+## Fabric Geocoding Notebook: Places API (Legacy) Switch
+- The Fabric notebook geocoding call layer now uses **Google Places API (Legacy) - Find Place** (`findplacefromtext`) with `inputtype=textquery` and **Basic fields only** (`place_id,formatted_address,geometry,name`) to control field-based billing.
+- Optional Place Details fallback is supported behind a config flag: `enable_place_details_fallback` (default `False`).
+- Delta table schemas, pipeline orchestration, cache MERGE logic, and optimization steps are unchanged.
+- Use `scripts/validate_places_mappings.py` to score offline mapping quality with no Google API calls. It compares input vs. returned address components, detects city-level/partial matches, optionally checks distance against expected coordinates, and writes record-level flags plus a confidence score.
+
+References:
+- Find Place (Legacy): https://developers.google.com/maps/documentation/places/web-service/legacy/search-find-place
+- Legacy place data fields (Basic vs Contact vs Atmosphere): https://developers.google.com/maps/documentation/places/web-service/legacy/place-data-fields
+- Place Search (Legacy) overview: https://developers.google.cn/maps/documentation/places/web-service/legacy/search?hl=en
+- Usage & Billing: https://developers.google.com/maps/documentation/places/web-service/usage-and-billing
+- Pricing: https://developers.google.com/maps/billing-and-pricing/pricing

--- a/fabric_geocode_pipeline_notebook.py
+++ b/fabric_geocode_pipeline_notebook.py
@@ -1,0 +1,498 @@
+# =========================================================
+# 1. Imports
+# =========================================================
+
+import json
+import random
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime
+
+import requests
+from pyspark.sql import functions as F
+from pyspark.sql import types as T
+
+
+# =========================================================
+# 2. Configuration
+# =========================================================
+
+# Runtime knobs for distributed geocoding behavior.
+CONFIG = {
+    "num_partitions": 128,
+    "max_workers_per_partition": 8,
+    "qps_per_partition": 20,
+    "max_retries": 5,
+    "base_delay": 0.5,
+    "jitter": 0.25,
+    "provider": "google_places_legacy_find_place",
+    "enable_place_details_fallback": False,
+}
+
+TABLE_SILVER_INPUT = "SLI_Silver.sli_silver_address_strandardization"
+TABLE_CACHE = "SLI_Silver.address_geocode_cache"
+TABLE_FAILURES = "SLI_Silver.address_geocode_failures"
+TABLE_GOLD = "SLI_Gold.address_geocode_enriched"
+
+PLACES_FIND_PLACE_URL = "https://maps.googleapis.com/maps/api/place/findplacefromtext/json"
+PLACES_DETAILS_URL = "https://maps.googleapis.com/maps/api/place/details/json"
+PLACES_BASIC_FIELDS = "place_id,formatted_address,geometry,name"
+
+API_KEY = dbutils.secrets.get(
+    scope="fabric-secrets",
+    key="google-geocode-api-key"
+)
+
+
+# =========================================================
+# 3. Delta Table DDL Creation
+# =========================================================
+
+spark.sql("CREATE SCHEMA IF NOT EXISTS SLI_Silver")
+spark.sql("CREATE SCHEMA IF NOT EXISTS SLI_Gold")
+
+spark.sql(f"""
+CREATE TABLE IF NOT EXISTS {TABLE_CACHE} (
+    canonical_address STRING,
+    formatted_address STRING,
+    place_id STRING,
+    lat DOUBLE,
+    lng DOUBLE,
+    provider STRING,
+    geocode_ts TIMESTAMP
+)
+USING DELTA
+""")
+
+spark.sql(f"""
+CREATE TABLE IF NOT EXISTS {TABLE_FAILURES} (
+    canonical_address STRING,
+    http_status INT,
+    error_type STRING,
+    error_message STRING,
+    response_snippet STRING,
+    attempt_ts TIMESTAMP
+)
+USING DELTA
+""")
+
+spark.sql(f"""
+CREATE TABLE IF NOT EXISTS {TABLE_GOLD} (
+    PARENT_PREM_ID STRING,
+    PREM_ID STRING,
+    canonical_address STRING,
+    formatted_address STRING,
+    place_id STRING,
+    lat DOUBLE,
+    lng DOUBLE
+)
+USING DELTA
+""")
+
+
+# =========================================================
+# 4. Read Silver Table
+# =========================================================
+
+silver_df = (
+    spark.table(TABLE_SILVER_INPUT)
+    .select("PARENT_PREM_ID", "PREM_ID", "canonical_address")
+    .filter(F.col("canonical_address").isNotNull())
+    .filter(F.length(F.trim(F.col("canonical_address"))) > 0)
+)
+
+
+# =========================================================
+# 5. Address Deduplication
+# =========================================================
+
+distinct_addresses_df = (
+    silver_df
+    .select(F.trim(F.col("canonical_address")).alias("canonical_address"))
+    .dropDuplicates(["canonical_address"])
+)
+
+
+# =========================================================
+# 6. Cache Lookup (Left Anti Join)
+# =========================================================
+
+cache_df = spark.table(TABLE_CACHE).select("canonical_address").dropDuplicates(["canonical_address"])
+
+cache_miss_df = (
+    distinct_addresses_df.alias("d")
+    .join(cache_df.alias("c"), on="canonical_address", how="left_anti")
+    .repartition(CONFIG["num_partitions"], "canonical_address")
+)
+
+cache_miss_count = cache_miss_df.count()
+
+
+# =========================================================
+# 7. Distributed Geocoding Engine (mapPartitions + ThreadPoolExecutor)
+# =========================================================
+
+result_schema = T.StructType([
+    T.StructField("canonical_address", T.StringType(), False),
+    T.StructField("formatted_address", T.StringType(), True),
+    T.StructField("place_id", T.StringType(), True),
+    T.StructField("lat", T.DoubleType(), True),
+    T.StructField("lng", T.DoubleType(), True),
+    T.StructField("provider", T.StringType(), True),
+    T.StructField("geocode_ts", T.TimestampType(), True),
+    T.StructField("http_status", T.IntegerType(), True),
+    T.StructField("error_type", T.StringType(), True),
+    T.StructField("error_message", T.StringType(), True),
+    T.StructField("response_snippet", T.StringType(), True),
+    T.StructField("attempt_ts", T.TimestampType(), True),
+    T.StructField("is_success", T.BooleanType(), False),
+])
+
+
+def geocode_partition(partition_iter):
+    """
+    Runs inside each Spark partition:
+    - Uses a shared requests.Session for connection reuse.
+    - Uses ThreadPoolExecutor for concurrent API calls per partition.
+    - Applies partition-local rate limiting and retry/backoff with jitter.
+    """
+    addresses = [row["canonical_address"] for row in partition_iter]
+    if not addresses:
+        return iter([])
+
+    session = requests.Session()
+    min_interval = 1.0 / max(1, CONFIG["qps_per_partition"])
+
+    # Shared mutable timestamp for rate-limiting across partition threads.
+    last_call = {"ts": 0.0}
+
+    def call_places_details(place_id):
+        response = session.get(
+            PLACES_DETAILS_URL,
+            params={
+                "place_id": place_id,
+                "fields": PLACES_BASIC_FIELDS,
+                "key": API_KEY,
+            },
+            timeout=20,
+        )
+        payload = response.json() if response.text else {}
+        return response.status_code, payload, response.text
+
+    def call_api(canonical_address):
+        retries = 0
+        while retries <= CONFIG["max_retries"]:
+            try:
+                # Partition-local QPS throttle.
+                now = time.time()
+                elapsed = now - last_call["ts"]
+                if elapsed < min_interval:
+                    time.sleep(min_interval - elapsed)
+                last_call["ts"] = time.time()
+
+                response = session.get(
+                    PLACES_FIND_PLACE_URL,
+                    params={
+                        "input": canonical_address,
+                        "inputtype": "textquery",
+                        "fields": PLACES_BASIC_FIELDS,
+                        "key": API_KEY,
+                    },
+                    timeout=20,
+                )
+                http_status = response.status_code
+                payload = response.json() if response.text else {}
+                api_status = payload.get("status")
+
+                if http_status == 200 and api_status == "OK":
+                    first = payload.get("candidates", [{}])[0]
+                    place_id = first.get("place_id")
+                    formatted_address = first.get("formatted_address")
+                    location = first.get("geometry", {}).get("location", {})
+
+                    if (
+                        CONFIG.get("enable_place_details_fallback", False)
+                        and place_id
+                        and (
+                            formatted_address is None
+                            or location.get("lat") is None
+                            or location.get("lng") is None
+                        )
+                    ):
+                        details_http_status, details_payload, _ = call_places_details(place_id)
+                        if details_http_status == 200 and details_payload.get("status") == "OK":
+                            details_result = details_payload.get("result", {})
+                            formatted_address = details_result.get("formatted_address") or formatted_address
+                            location = details_result.get("geometry", {}).get("location", location)
+
+                    return {
+                        "canonical_address": canonical_address,
+                        "formatted_address": formatted_address,
+                        "place_id": place_id,
+                        "lat": float(location.get("lat")) if location.get("lat") is not None else None,
+                        "lng": float(location.get("lng")) if location.get("lng") is not None else None,
+                        "provider": CONFIG["provider"],
+                        "geocode_ts": datetime.utcnow(),
+                        "http_status": None,
+                        "error_type": None,
+                        "error_message": None,
+                        "response_snippet": None,
+                        "attempt_ts": datetime.utcnow(),
+                        "is_success": True,
+                    }
+
+                if http_status == 200 and api_status == "ZERO_RESULTS":
+                    return {
+                        "canonical_address": canonical_address,
+                        "formatted_address": None,
+                        "place_id": None,
+                        "lat": None,
+                        "lng": None,
+                        "provider": None,
+                        "geocode_ts": None,
+                        "http_status": 200,
+                        "error_type": "ZERO_RESULTS",
+                        "error_message": "No geocoding match found.",
+                        "response_snippet": json.dumps(payload)[:1000],
+                        "attempt_ts": datetime.utcnow(),
+                        "is_success": False,
+                    }
+
+                retriable = (
+                    (http_status == 429)
+                    or (500 <= http_status <= 599)
+                    or (api_status in {"OVER_QUERY_LIMIT", "UNKNOWN_ERROR"})
+                )
+                if retriable and retries < CONFIG["max_retries"]:
+                    sleep_s = (CONFIG["base_delay"] * (2 ** retries)) + random.uniform(0, CONFIG["jitter"])
+                    time.sleep(sleep_s)
+                    retries += 1
+                    continue
+
+                return {
+                    "canonical_address": canonical_address,
+                    "formatted_address": None,
+                    "place_id": None,
+                    "lat": None,
+                    "lng": None,
+                    "provider": None,
+                    "geocode_ts": None,
+                    "http_status": http_status,
+                    "error_type": api_status or "HTTP_ERROR",
+                    "error_message": f"Geocode request failed after retries={retries}",
+                    "response_snippet": response.text[:1000] if response.text else None,
+                    "attempt_ts": datetime.utcnow(),
+                    "is_success": False,
+                }
+
+            except Exception as ex:
+                if retries < CONFIG["max_retries"]:
+                    sleep_s = (CONFIG["base_delay"] * (2 ** retries)) + random.uniform(0, CONFIG["jitter"])
+                    time.sleep(sleep_s)
+                    retries += 1
+                    continue
+                return {
+                    "canonical_address": canonical_address,
+                    "formatted_address": None,
+                    "place_id": None,
+                    "lat": None,
+                    "lng": None,
+                    "provider": None,
+                    "geocode_ts": None,
+                    "http_status": None,
+                    "error_type": "NETWORK_EXCEPTION",
+                    "error_message": f"Max retry exceeded: {str(ex)[:400]}",
+                    "response_snippet": None,
+                    "attempt_ts": datetime.utcnow(),
+                    "is_success": False,
+                }
+
+        return {
+            "canonical_address": canonical_address,
+            "formatted_address": None,
+            "place_id": None,
+            "lat": None,
+            "lng": None,
+            "provider": None,
+            "geocode_ts": None,
+            "http_status": None,
+            "error_type": "MAX_RETRY_EXCEEDED",
+            "error_message": "Retry loop exited unexpectedly.",
+            "response_snippet": None,
+            "attempt_ts": datetime.utcnow(),
+            "is_success": False,
+        }
+
+    max_workers = max(1, CONFIG["max_workers_per_partition"])
+    results = []
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        futures = [pool.submit(call_api, addr) for addr in addresses]
+        for future in as_completed(futures):
+            results.append(future.result())
+
+    return iter(results)
+
+
+# =========================================================
+# 8. Execute Geocoding Job
+# =========================================================
+
+geocode_result_df = spark.createDataFrame(
+    cache_miss_df.rdd.mapPartitions(geocode_partition),
+    schema=result_schema,
+)
+
+
+# =========================================================
+# 9. Split Success vs Failures
+# =========================================================
+
+success_df = (
+    geocode_result_df
+    .filter(F.col("is_success") == True)
+    .select(
+        "canonical_address",
+        "formatted_address",
+        "place_id",
+        "lat",
+        "lng",
+        "provider",
+        "geocode_ts",
+    )
+)
+
+failure_df = (
+    geocode_result_df
+    .filter(F.col("is_success") == False)
+    .select(
+        "canonical_address",
+        "http_status",
+        "error_type",
+        "error_message",
+        "response_snippet",
+        "attempt_ts",
+    )
+)
+
+success_count = success_df.count()
+failure_count = failure_df.count()
+
+
+# =========================================================
+# 10. Write Failures (Dead Letter Table)
+# =========================================================
+
+if failure_count > 0:
+    (
+        failure_df
+        .repartition(max(1, CONFIG["num_partitions"] // 4), "canonical_address")
+        .write
+        .format("delta")
+        .mode("append")
+        .saveAsTable(TABLE_FAILURES)
+    )
+
+
+# =========================================================
+# 11. Upsert Cache Table
+# =========================================================
+
+if success_count > 0:
+    upsert_src_df = success_df.repartition(max(1, CONFIG["num_partitions"] // 4), "canonical_address")
+    upsert_src_df.createOrReplaceTempView("tmp_geocode_success")
+
+    spark.sql(f"""
+    MERGE INTO {TABLE_CACHE} AS tgt
+    USING tmp_geocode_success AS src
+    ON tgt.canonical_address = src.canonical_address
+    WHEN MATCHED THEN UPDATE SET
+      tgt.formatted_address = src.formatted_address,
+      tgt.place_id = src.place_id,
+      tgt.lat = src.lat,
+      tgt.lng = src.lng,
+      tgt.provider = src.provider,
+      tgt.geocode_ts = src.geocode_ts
+    WHEN NOT MATCHED THEN INSERT (
+      canonical_address,
+      formatted_address,
+      place_id,
+      lat,
+      lng,
+      provider,
+      geocode_ts
+    ) VALUES (
+      src.canonical_address,
+      src.formatted_address,
+      src.place_id,
+      src.lat,
+      src.lng,
+      src.provider,
+      src.geocode_ts
+    )
+    """)
+
+
+# =========================================================
+# 12. Join Cache Back to Original Dataset
+# =========================================================
+
+cache_latest_df = spark.table(TABLE_CACHE).select(
+    "canonical_address",
+    "formatted_address",
+    "place_id",
+    "lat",
+    "lng",
+)
+
+enriched_df = (
+    silver_df.alias("s")
+    .join(cache_latest_df.alias("c"), on="canonical_address", how="left")
+    .select(
+        "s.PARENT_PREM_ID",
+        "s.PREM_ID",
+        "s.canonical_address",
+        "c.formatted_address",
+        "c.place_id",
+        "c.lat",
+        "c.lng",
+    )
+)
+
+
+# =========================================================
+# 13. Write Gold Table
+# =========================================================
+
+(
+    enriched_df
+    .repartition(CONFIG["num_partitions"], "canonical_address")
+    .write
+    .format("delta")
+    .mode("overwrite")
+    .option("overwriteSchema", "true")
+    .saveAsTable(TABLE_GOLD)
+)
+
+
+# =========================================================
+# 14. Delta Optimization (OPTIMIZE + ZORDER + VACUUM)
+# =========================================================
+
+spark.sql(f"OPTIMIZE {TABLE_CACHE} ZORDER BY (canonical_address)")
+spark.sql(f"OPTIMIZE {TABLE_GOLD} ZORDER BY (canonical_address)")
+spark.sql(f"VACUUM {TABLE_CACHE} RETAIN 168 HOURS")
+spark.sql(f"VACUUM {TABLE_GOLD} RETAIN 168 HOURS")
+spark.sql(f"VACUUM {TABLE_FAILURES} RETAIN 168 HOURS")
+
+
+# =========================================================
+# 15. Runtime Metrics Summary
+# =========================================================
+
+cache_size_after_merge = spark.table(TABLE_CACHE).count()
+
+print("=== Geocoding Pipeline Metrics ===")
+print(f"Cache misses geocoded this run: {cache_miss_count}")
+print(f"Successful geocodes: {success_count}")
+print(f"Failed geocodes: {failure_count}")
+print(f"Cache size after merge: {cache_size_after_merge}")

--- a/fabric_places_mapping_validation_lightweight_notebook.py
+++ b/fabric_places_mapping_validation_lightweight_notebook.py
@@ -1,0 +1,491 @@
+# =========================================================
+# 1. Imports
+# =========================================================
+
+import math
+import re
+
+from pyspark.sql import functions as F
+from pyspark.sql import types as T
+
+
+# =========================================================
+# 2. Configuration
+# =========================================================
+
+CONFIG = {
+    "input_table": "SLI_Gold.address_geocode_enriched",
+    "validation_table": "SLI_Gold.address_geocode_validation_lightweight",
+    "summary_table": "SLI_Gold.address_geocode_validation_lightweight_summary",
+    "distance_threshold_km": 2.0,
+    "far_distance_threshold_km": 5.0,
+    "low_confidence_threshold": 0.55,
+    "num_output_partitions": 32,
+    "write_mode": "overwrite",
+}
+
+ALLOWED_LOCALITIES = {
+    "manhattan", "new york", "brooklyn", "queens", "bronx", "staten island",
+    "yonkers", "mount vernon", "new rochelle", "white plains", "peekskill", "rye",
+    "harrison", "mamaroneck", "larchmont", "tarrytown", "sleepy hollow", "ossining",
+    "dobbs ferry", "irvington", "hastings on hudson", "scarsdale", "greenburgh",
+    "eastchester", "pelham", "bronxville", "ardsley", "elmsford", "pleasantville",
+    "briarcliff manor", "bedford", "mount kisco", "chappaqua", "cortlandt",
+    "croton on hudson", "port chester",
+}
+
+ALLOWED_COUNTIES = {
+    "new york county", "kings county", "queens county", "bronx county",
+    "richmond county", "westchester county",
+}
+
+ALLOWED_REGION_BBOX = {
+    "min_lat": 40.49,
+    "max_lat": 41.35,
+    "min_lng": -74.35,
+    "max_lng": -73.45,
+}
+
+VALIDATION_SCHEMA = T.StructType([
+    T.StructField("normalized_input_address", T.StringType(), True),
+    T.StructField("normalized_formatted_address", T.StringType(), True),
+    T.StructField("input_house_number", T.StringType(), True),
+    T.StructField("output_house_number", T.StringType(), True),
+    T.StructField("input_street_normalized", T.StringType(), True),
+    T.StructField("output_street_normalized", T.StringType(), True),
+    T.StructField("input_city_normalized", T.StringType(), True),
+    T.StructField("output_city_normalized", T.StringType(), True),
+    T.StructField("input_state_normalized", T.StringType(), True),
+    T.StructField("output_state_normalized", T.StringType(), True),
+    T.StructField("input_zip_normalized", T.StringType(), True),
+    T.StructField("output_zip_normalized", T.StringType(), True),
+    T.StructField("street_match", T.BooleanType(), True),
+    T.StructField("house_number_match", T.BooleanType(), True),
+    T.StructField("city_match", T.BooleanType(), True),
+    T.StructField("state_match", T.BooleanType(), True),
+    T.StructField("zip_match", T.BooleanType(), True),
+    T.StructField("missing_street_in_output", T.BooleanType(), True),
+    T.StructField("street_present_but_house_missing", T.BooleanType(), True),
+    T.StructField("component_mismatch_count", T.IntegerType(), True),
+    T.StructField("is_city_level_match", T.BooleanType(), True),
+    T.StructField("is_partial_match", T.BooleanType(), True),
+    T.StructField("distance_km", T.DoubleType(), True),
+    T.StructField("is_far_distance", T.BooleanType(), True),
+    T.StructField("is_out_of_region", T.BooleanType(), True),
+    T.StructField("confidence_score", T.DoubleType(), True),
+    T.StructField("is_low_confidence", T.BooleanType(), True),
+    T.StructField("is_suspicious", T.BooleanType(), True),
+])
+
+
+# =========================================================
+# 3. Delta Table DDL Creation
+# =========================================================
+
+spark.sql("CREATE SCHEMA IF NOT EXISTS SLI_Gold")
+
+spark.sql(f"""
+CREATE TABLE IF NOT EXISTS {CONFIG['validation_table']} (
+    PARENT_PREM_ID STRING,
+    PREM_ID STRING,
+    canonical_address STRING,
+    formatted_address STRING,
+    place_id STRING,
+    lat DOUBLE,
+    lng DOUBLE,
+    normalized_input_address STRING,
+    normalized_formatted_address STRING,
+    input_house_number STRING,
+    output_house_number STRING,
+    input_street_normalized STRING,
+    output_street_normalized STRING,
+    input_city_normalized STRING,
+    output_city_normalized STRING,
+    input_state_normalized STRING,
+    output_state_normalized STRING,
+    input_zip_normalized STRING,
+    output_zip_normalized STRING,
+    street_match BOOLEAN,
+    house_number_match BOOLEAN,
+    city_match BOOLEAN,
+    state_match BOOLEAN,
+    zip_match BOOLEAN,
+    missing_street_in_output BOOLEAN,
+    street_present_but_house_missing BOOLEAN,
+    component_mismatch_count INT,
+    is_city_level_match BOOLEAN,
+    is_partial_match BOOLEAN,
+    distance_km DOUBLE,
+    is_far_distance BOOLEAN,
+    is_out_of_region BOOLEAN,
+    confidence_score DOUBLE,
+    is_low_confidence BOOLEAN,
+    is_suspicious BOOLEAN,
+    validation_ts TIMESTAMP
+)
+USING DELTA
+""")
+
+spark.sql(f"""
+CREATE TABLE IF NOT EXISTS {CONFIG['summary_table']} (
+    metric STRING,
+    value DOUBLE,
+    validation_ts TIMESTAMP
+)
+USING DELTA
+""")
+
+
+# =========================================================
+# 4. Read Input Delta Table
+# =========================================================
+
+input_df = spark.table(CONFIG["input_table"])
+
+
+# =========================================================
+# 5. Lightweight Helper Functions
+# =========================================================
+
+STREET_SUFFIX_MAP = {
+    "street": "st", "st": "st", "avenue": "ave", "ave": "ave", "road": "rd", "rd": "rd",
+    "boulevard": "blvd", "blvd": "blvd", "drive": "dr", "dr": "dr", "lane": "ln", "ln": "ln",
+    "court": "ct", "ct": "ct", "place": "pl", "pl": "pl", "terrace": "ter", "ter": "ter",
+    "parkway": "pkwy", "pkwy": "pkwy", "circle": "cir", "cir": "cir", "highway": "hwy", "hwy": "hwy",
+}
+
+
+def clean_text(value):
+    if value is None:
+        return ""
+    text = str(value).strip().lower()
+    text = re.sub(r"[^a-z0-9\s]", " ", text)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def normalize_state(value):
+    text = clean_text(value)
+    if text in {"ny", "new york"}:
+        return "NY"
+    return text.upper() if text else ""
+
+
+def normalize_street(value):
+    text = clean_text(value)
+    if not text:
+        return ""
+    return " ".join(STREET_SUFFIX_MAP.get(token, token) for token in text.split())
+
+
+def extract_zip(value):
+    match = re.search(r"\b(\d{5})(?:-\d{4})?\b", str(value or ""))
+    return match.group(1) if match else None
+
+
+def extract_house_number(value):
+    match = re.match(r"^\s*(\d+[a-zA-Z\-]?)\b", str(value or ""))
+    return match.group(1) if match else None
+
+
+def parse_address(address):
+    parts = [part.strip() for part in str(address or "").split(",") if part.strip()]
+    street = parts[0] if len(parts) > 0 else ""
+    city = parts[1] if len(parts) > 1 else ""
+    state_zip = parts[2] if len(parts) > 2 else ""
+    country = parts[3] if len(parts) > 3 else ""
+    state = normalize_state(state_zip.split()[0]) if state_zip.split() else ""
+    zip_code = extract_zip(state_zip) or extract_zip(country)
+    return street, city, state, zip_code
+
+
+def present_and_equal(left, right):
+    return bool(left and right and left == right)
+
+
+def haversine_km(lat1, lon1, lat2, lon2):
+    try:
+        lat1_f, lon1_f, lat2_f, lon2_f = map(float, [lat1, lon1, lat2, lon2])
+    except (TypeError, ValueError):
+        return None
+    radius_km = 6371.0088
+    dlat = math.radians(lat2_f - lat1_f)
+    dlon = math.radians(lon2_f - lon1_f)
+    a = (
+        math.sin(dlat / 2) ** 2
+        + math.cos(math.radians(lat1_f)) * math.cos(math.radians(lat2_f)) * math.sin(dlon / 2) ** 2
+    )
+    return 2 * radius_km * math.asin(math.sqrt(a))
+
+
+def locality_allowed(*values):
+    for value in values:
+        text = clean_text(value)
+        if not text:
+            continue
+        if text in ALLOWED_LOCALITIES or text in ALLOWED_COUNTIES:
+            return True
+        if any(token in text for token in ALLOWED_LOCALITIES | ALLOWED_COUNTIES):
+            return True
+    return False
+
+
+def coordinates_in_region(lat, lng):
+    try:
+        lat_f = float(lat)
+        lng_f = float(lng)
+    except (TypeError, ValueError):
+        return False
+    return (
+        ALLOWED_REGION_BBOX["min_lat"] <= lat_f <= ALLOWED_REGION_BBOX["max_lat"]
+        and ALLOWED_REGION_BBOX["min_lng"] <= lng_f <= ALLOWED_REGION_BBOX["max_lng"]
+    )
+
+
+def score_match(street_match, house_number_match, city_match, state_match, zip_match, is_city_level_match, is_partial_match, distance_km, is_out_of_region):
+    score = 0.0
+    score += 0.35 * (1.0 if street_match and house_number_match else 0.75 if street_match else 0.0)
+    score += 0.20 * float(city_match)
+    score += 0.15 * float(state_match)
+    score += 0.10 * float(zip_match)
+    score += 0.10 * (0.0 if is_city_level_match else 0.5 if is_partial_match else 1.0)
+    score += 0.10 * (0.5 if distance_km is None else 1.0 if distance_km <= CONFIG["distance_threshold_km"] else 0.5 if distance_km <= CONFIG["far_distance_threshold_km"] else 0.0)
+    score += 0.10 * float(not is_out_of_region)
+    return round(max(0.0, min(1.0, score)), 4)
+
+
+# =========================================================
+# 6. Validation UDF
+# =========================================================
+
+@F.udf(returnType=VALIDATION_SCHEMA)
+def validate_mapping_udf(canonical_address, street, city, state, postal_code, borough, county, formatted_address, lat, lng, input_lat, input_lng):
+    input_street = street or ""
+    input_city = city or ""
+    input_state = state or ""
+    input_zip = postal_code or ""
+
+    if not input_street and canonical_address:
+        parsed_street, parsed_city, parsed_state, parsed_zip = parse_address(canonical_address)
+        input_street = parsed_street or input_street
+        input_city = parsed_city or input_city
+        input_state = parsed_state or input_state
+        input_zip = parsed_zip or input_zip
+
+    output_street, output_city, output_state, output_zip = parse_address(formatted_address)
+
+    input_street_normalized = normalize_street(input_street)
+    output_street_normalized = normalize_street(output_street)
+    input_city_normalized = clean_text(input_city)
+    output_city_normalized = clean_text(output_city)
+    input_state_normalized = normalize_state(input_state)
+    output_state_normalized = normalize_state(output_state)
+    input_zip_normalized = extract_zip(input_zip)
+    output_zip_normalized = extract_zip(output_zip)
+    input_house_number = extract_house_number(input_street)
+    output_house_number = extract_house_number(output_street)
+
+    street_match = present_and_equal(input_street_normalized, output_street_normalized)
+    house_number_match = present_and_equal(input_house_number, output_house_number)
+    city_match = present_and_equal(input_city_normalized, output_city_normalized)
+    state_match = present_and_equal(input_state_normalized, output_state_normalized)
+    zip_match = present_and_equal(input_zip_normalized, output_zip_normalized)
+    missing_street_in_output = bool(input_street_normalized and not output_street_normalized)
+    street_present_but_house_missing = bool(input_house_number and not output_house_number)
+
+    component_mismatch_count = sum([
+        int(bool(input_street_normalized) and not street_match),
+        int(bool(input_city_normalized) and not city_match),
+        int(bool(input_state_normalized) and not state_match),
+        int(bool(input_zip_normalized) and not zip_match),
+    ])
+
+    output_looks_like_city_only = bool(output_city_normalized and output_street_normalized == output_city_normalized and not output_house_number)
+    is_city_level_match = bool((input_street_normalized or input_house_number) and ((not output_house_number and output_city_normalized) or output_looks_like_city_only))
+    is_partial_match = bool((input_street_normalized or input_house_number) and not is_city_level_match and output_street_normalized and input_house_number and not output_house_number)
+
+    distance_km = haversine_km(input_lat, input_lng, lat, lng)
+    is_far_distance = bool(distance_km is not None and distance_km > CONFIG["far_distance_threshold_km"])
+
+    formatted_text = clean_text(formatted_address)
+    is_out_of_region = not (
+        locality_allowed(borough, county, formatted_text, input_city_normalized, output_city_normalized)
+        or coordinates_in_region(lat, lng)
+    )
+
+    confidence_score = score_match(
+        street_match=street_match,
+        house_number_match=house_number_match,
+        city_match=city_match,
+        state_match=state_match,
+        zip_match=zip_match,
+        is_city_level_match=is_city_level_match,
+        is_partial_match=is_partial_match,
+        distance_km=distance_km,
+        is_out_of_region=is_out_of_region,
+    )
+    is_low_confidence = bool(confidence_score < CONFIG["low_confidence_threshold"])
+    is_suspicious = bool(
+        is_low_confidence
+        or is_city_level_match
+        or is_partial_match
+        or is_far_distance
+        or is_out_of_region
+        or component_mismatch_count >= 2
+    )
+
+    return (
+        clean_text(" ".join(filter(None, [input_street, input_city, input_state, input_zip]))),
+        clean_text(formatted_address),
+        input_house_number,
+        output_house_number,
+        input_street_normalized,
+        output_street_normalized,
+        input_city_normalized,
+        output_city_normalized,
+        input_state_normalized,
+        output_state_normalized,
+        input_zip_normalized,
+        output_zip_normalized,
+        street_match,
+        house_number_match,
+        city_match,
+        state_match,
+        zip_match,
+        missing_street_in_output,
+        street_present_but_house_missing,
+        component_mismatch_count,
+        is_city_level_match,
+        is_partial_match,
+        distance_km,
+        is_far_distance,
+        is_out_of_region,
+        confidence_score,
+        is_low_confidence,
+        is_suspicious,
+    )
+
+
+# =========================================================
+# 7. Apply Validation Logic
+# =========================================================
+
+def first_available_column(df, names, data_type="string"):
+    for name in names:
+        if name in df.columns:
+            return F.col(name).cast(data_type)
+    return F.lit(None).cast(data_type)
+
+
+validated_df = (
+    input_df
+    .withColumn(
+        "validation",
+        validate_mapping_udf(
+            F.col("canonical_address"),
+            first_available_column(input_df, ["street", "input_street", "address_line_1"]),
+            first_available_column(input_df, ["city", "input_city"]),
+            first_available_column(input_df, ["state", "input_state"]),
+            first_available_column(input_df, ["zip", "zipcode", "postal_code", "input_zip"]),
+            first_available_column(input_df, ["borough"]),
+            first_available_column(input_df, ["county"]),
+            F.col("formatted_address"),
+            F.col("lat"),
+            F.col("lng"),
+            first_available_column(input_df, ["input_lat", "expected_lat"], "double"),
+            first_available_column(input_df, ["input_lng", "input_lon", "expected_lng", "expected_lon"], "double"),
+        )
+    )
+    .select("*", "validation.*")
+    .drop("validation")
+    .withColumn("validation_ts", F.current_timestamp())
+)
+
+
+# =========================================================
+# 8. Write Validation Delta Table
+# =========================================================
+
+(
+    validated_df
+    .repartition(CONFIG["num_output_partitions"])
+    .write
+    .format("delta")
+    .mode(CONFIG["write_mode"])
+    .option("overwriteSchema", "true")
+    .saveAsTable(CONFIG["validation_table"])
+)
+
+
+# =========================================================
+# 9. Build Summary Metrics
+# =========================================================
+
+summary_df = (
+    validated_df
+    .agg(
+        F.count(F.lit(1)).alias("record_count"),
+        (F.avg(F.when(F.col("confidence_score") >= 0.85, 1.0).otherwise(0.0)) * 100.0).alias("pct_high_confidence"),
+        (F.avg(F.when(F.col("is_low_confidence"), 1.0).otherwise(0.0)) * 100.0).alias("pct_low_confidence"),
+        (F.avg(F.when(F.col("is_suspicious"), 1.0).otherwise(0.0)) * 100.0).alias("pct_likely_incorrect"),
+        (F.avg(F.when(F.col("is_city_level_match"), 1.0).otherwise(0.0)) * 100.0).alias("pct_city_level_match"),
+        (F.avg(F.when(F.col("is_partial_match"), 1.0).otherwise(0.0)) * 100.0).alias("pct_partial_match"),
+        (F.avg(F.when(F.col("is_far_distance"), 1.0).otherwise(0.0)) * 100.0).alias("pct_far_distance"),
+        (F.avg(F.when(F.col("is_out_of_region"), 1.0).otherwise(0.0)) * 100.0).alias("pct_out_of_region"),
+    )
+    .select(
+        F.array(
+            F.struct(F.lit("record_count").alias("metric"), F.col("record_count").cast("double").alias("value")),
+            F.struct(F.lit("pct_high_confidence").alias("metric"), F.round(F.col("pct_high_confidence"), 2).alias("value")),
+            F.struct(F.lit("pct_low_confidence").alias("metric"), F.round(F.col("pct_low_confidence"), 2).alias("value")),
+            F.struct(F.lit("pct_likely_incorrect").alias("metric"), F.round(F.col("pct_likely_incorrect"), 2).alias("value")),
+            F.struct(F.lit("pct_city_level_match").alias("metric"), F.round(F.col("pct_city_level_match"), 2).alias("value")),
+            F.struct(F.lit("pct_partial_match").alias("metric"), F.round(F.col("pct_partial_match"), 2).alias("value")),
+            F.struct(F.lit("pct_far_distance").alias("metric"), F.round(F.col("pct_far_distance"), 2).alias("value")),
+            F.struct(F.lit("pct_out_of_region").alias("metric"), F.round(F.col("pct_out_of_region"), 2).alias("value")),
+        ).alias("metrics")
+    )
+    .select(F.explode("metrics").alias("metric_struct"))
+    .select(F.col("metric_struct.metric").alias("metric"), F.col("metric_struct.value").alias("value"))
+    .withColumn("validation_ts", F.current_timestamp())
+)
+
+
+# =========================================================
+# 10. Write Summary Delta Table
+# =========================================================
+
+(
+    summary_df
+    .write
+    .format("delta")
+    .mode(CONFIG["write_mode"])
+    .option("overwriteSchema", "true")
+    .saveAsTable(CONFIG["summary_table"])
+)
+
+
+# =========================================================
+# 11. Delta Optimization
+# =========================================================
+
+spark.sql(f"OPTIMIZE {CONFIG['validation_table']} ZORDER BY (canonical_address, place_id)")
+spark.sql(f"OPTIMIZE {CONFIG['summary_table']} ZORDER BY (metric)")
+spark.sql(f"VACUUM {CONFIG['validation_table']} RETAIN 168 HOURS")
+spark.sql(f"VACUUM {CONFIG['summary_table']} RETAIN 168 HOURS")
+
+
+# =========================================================
+# 12. Runtime Metrics Summary
+# =========================================================
+
+summary_rows = {row["metric"]: row["value"] for row in summary_df.collect()}
+
+print("=== Lightweight Places Mapping Validation Metrics ===")
+print(f"Record count: {summary_rows.get('record_count', 0)}")
+print(f"% High confidence: {summary_rows.get('pct_high_confidence', 0)}")
+print(f"% Low confidence: {summary_rows.get('pct_low_confidence', 0)}")
+print(f"% Likely incorrect: {summary_rows.get('pct_likely_incorrect', 0)}")
+print(f"% City-level match: {summary_rows.get('pct_city_level_match', 0)}")
+print(f"% Partial match: {summary_rows.get('pct_partial_match', 0)}")
+print(f"% Far distance: {summary_rows.get('pct_far_distance', 0)}")
+print(f"% Out of region: {summary_rows.get('pct_out_of_region', 0)}")

--- a/fabric_places_mapping_validation_lightweight_notebook.py
+++ b/fabric_places_mapping_validation_lightweight_notebook.py
@@ -241,14 +241,13 @@ def coordinates_in_region(lat, lng):
     )
 
 
-def score_match(street_match, house_number_match, city_match, state_match, zip_match, is_city_level_match, is_partial_match, distance_km, is_out_of_region):
+def score_match(street_match, house_number_match, city_match, state_match, zip_match, is_city_level_match, is_partial_match, is_out_of_region):
     score = 0.0
     score += 0.35 * (1.0 if street_match and house_number_match else 0.75 if street_match else 0.0)
     score += 0.20 * float(city_match)
     score += 0.15 * float(state_match)
     score += 0.10 * float(zip_match)
     score += 0.10 * (0.0 if is_city_level_match else 0.5 if is_partial_match else 1.0)
-    score += 0.10 * (0.5 if distance_km is None else 1.0 if distance_km <= CONFIG["distance_threshold_km"] else 0.5 if distance_km <= CONFIG["far_distance_threshold_km"] else 0.0)
     score += 0.10 * float(not is_out_of_region)
     return round(max(0.0, min(1.0, score)), 4)
 
@@ -320,7 +319,6 @@ def validate_mapping_udf(canonical_address, street, city, state, postal_code, bo
         zip_match=zip_match,
         is_city_level_match=is_city_level_match,
         is_partial_match=is_partial_match,
-        distance_km=distance_km,
         is_out_of_region=is_out_of_region,
     )
     is_low_confidence = bool(confidence_score < CONFIG["low_confidence_threshold"])

--- a/fabric_places_mapping_validation_notebook.py
+++ b/fabric_places_mapping_validation_notebook.py
@@ -1,0 +1,538 @@
+# =========================================================
+# 1. Imports
+# =========================================================
+
+import math
+import re
+from typing import Dict
+
+from pyspark.sql import functions as F
+from pyspark.sql import types as T
+
+
+# =========================================================
+# 2. Configuration
+# =========================================================
+
+CONFIG = {
+    "input_table": "SLI_Gold.address_geocode_enriched",
+    "validation_table": "SLI_Gold.address_geocode_validation",
+    "summary_table": "SLI_Gold.address_geocode_validation_summary",
+    "distance_threshold_km": 2.0,
+    "far_distance_threshold_km": 5.0,
+    "low_confidence_threshold": 0.55,
+    "street_weight": 0.35,
+    "city_weight": 0.20,
+    "state_weight": 0.15,
+    "zip_weight": 0.10,
+    "granularity_weight": 0.10,
+    "distance_weight": 0.10,
+    "region_weight": 0.10,
+    "write_mode": "overwrite",
+    "num_output_partitions": 32,
+}
+
+ALLOWED_LOCALITIES = {
+    "manhattan", "new york", "brooklyn", "queens", "bronx", "staten island",
+    "yonkers", "mount vernon", "new rochelle", "white plains", "peekskill", "rye",
+    "harrison", "mamaroneck", "larchmont", "tarrytown", "sleepy hollow", "ossining",
+    "dobbs ferry", "irvington", "hastings on hudson", "scarsdale", "greenburgh",
+    "eastchester", "pelham", "bronxville", "ardsley", "elmsford", "pleasantville",
+    "briarcliff manor", "bedford", "mount kisco", "chappaqua", "cortlandt",
+    "croton on hudson", "port chester",
+}
+
+ALLOWED_COUNTIES = {
+    "new york county", "kings county", "queens county", "bronx county",
+    "richmond county", "westchester county",
+}
+
+ALLOWED_REGION_BBOX = {
+    "min_lat": 40.49,
+    "max_lat": 41.35,
+    "min_lng": -74.35,
+    "max_lng": -73.45,
+}
+
+STATE_ABBREVIATIONS = {
+    "alabama": "AL", "alaska": "AK", "arizona": "AZ", "arkansas": "AR",
+    "california": "CA", "colorado": "CO", "connecticut": "CT", "delaware": "DE",
+    "florida": "FL", "georgia": "GA", "hawaii": "HI", "idaho": "ID",
+    "illinois": "IL", "indiana": "IN", "iowa": "IA", "kansas": "KS",
+    "kentucky": "KY", "louisiana": "LA", "maine": "ME", "maryland": "MD",
+    "massachusetts": "MA", "michigan": "MI", "minnesota": "MN", "mississippi": "MS",
+    "missouri": "MO", "montana": "MT", "nebraska": "NE", "nevada": "NV",
+    "new hampshire": "NH", "new jersey": "NJ", "new mexico": "NM", "new york": "NY",
+    "north carolina": "NC", "north dakota": "ND", "ohio": "OH", "oklahoma": "OK",
+    "oregon": "OR", "pennsylvania": "PA", "rhode island": "RI", "south carolina": "SC",
+    "south dakota": "SD", "tennessee": "TN", "texas": "TX", "utah": "UT",
+    "vermont": "VT", "virginia": "VA", "washington": "WA", "west virginia": "WV",
+    "wisconsin": "WI", "wyoming": "WY", "district of columbia": "DC",
+}
+
+STREET_SUFFIXES = {
+    "street": "st", "st": "st", "avenue": "ave", "ave": "ave", "road": "rd", "rd": "rd",
+    "boulevard": "blvd", "blvd": "blvd", "drive": "dr", "dr": "dr", "lane": "ln", "ln": "ln",
+    "court": "ct", "ct": "ct", "place": "pl", "pl": "pl", "terrace": "ter", "ter": "ter",
+    "parkway": "pkwy", "pkwy": "pkwy", "circle": "cir", "cir": "cir", "highway": "hwy", "hwy": "hwy",
+}
+
+
+# =========================================================
+# 3. Delta Table DDL Creation
+# =========================================================
+
+spark.sql("CREATE SCHEMA IF NOT EXISTS SLI_Gold")
+
+spark.sql(f"""
+CREATE TABLE IF NOT EXISTS {CONFIG['validation_table']} (
+    PARENT_PREM_ID STRING,
+    PREM_ID STRING,
+    canonical_address STRING,
+    formatted_address STRING,
+    place_id STRING,
+    lat DOUBLE,
+    lng DOUBLE,
+    normalized_input_address STRING,
+    normalized_formatted_address STRING,
+    input_house_number STRING,
+    output_house_number STRING,
+    input_street_normalized STRING,
+    output_street_normalized STRING,
+    input_city_normalized STRING,
+    output_city_normalized STRING,
+    input_state_normalized STRING,
+    output_state_normalized STRING,
+    input_zip_normalized STRING,
+    output_zip_normalized STRING,
+    street_match BOOLEAN,
+    house_number_match BOOLEAN,
+    city_match BOOLEAN,
+    state_match BOOLEAN,
+    zip_match BOOLEAN,
+    missing_street_in_output BOOLEAN,
+    street_present_but_house_missing BOOLEAN,
+    component_mismatch_count INT,
+    is_city_level_match BOOLEAN,
+    is_partial_match BOOLEAN,
+    distance_km DOUBLE,
+    is_far_distance BOOLEAN,
+    is_out_of_region BOOLEAN,
+    region_match BOOLEAN,
+    confidence_score DOUBLE,
+    is_low_confidence BOOLEAN,
+    is_suspicious BOOLEAN,
+    validation_ts TIMESTAMP
+)
+USING DELTA
+""")
+
+spark.sql(f"""
+CREATE TABLE IF NOT EXISTS {CONFIG['summary_table']} (
+    metric STRING,
+    value DOUBLE,
+    validation_ts TIMESTAMP
+)
+USING DELTA
+""")
+
+
+# =========================================================
+# 4. Read Input Delta Table
+# =========================================================
+
+input_df = spark.table(CONFIG["input_table"])
+
+# The validator supports either split input columns or just canonical_address.
+# Optional columns used if present: street, city, state, zip, input_lat, input_lng,
+# borough, county.
+
+
+# =========================================================
+# 5. Validation Helper Functions
+# =========================================================
+
+validation_schema = T.StructType([
+    T.StructField("normalized_input_address", T.StringType(), True),
+    T.StructField("normalized_formatted_address", T.StringType(), True),
+    T.StructField("input_house_number", T.StringType(), True),
+    T.StructField("output_house_number", T.StringType(), True),
+    T.StructField("input_street_normalized", T.StringType(), True),
+    T.StructField("output_street_normalized", T.StringType(), True),
+    T.StructField("input_city_normalized", T.StringType(), True),
+    T.StructField("output_city_normalized", T.StringType(), True),
+    T.StructField("input_state_normalized", T.StringType(), True),
+    T.StructField("output_state_normalized", T.StringType(), True),
+    T.StructField("input_zip_normalized", T.StringType(), True),
+    T.StructField("output_zip_normalized", T.StringType(), True),
+    T.StructField("street_match", T.BooleanType(), True),
+    T.StructField("house_number_match", T.BooleanType(), True),
+    T.StructField("city_match", T.BooleanType(), True),
+    T.StructField("state_match", T.BooleanType(), True),
+    T.StructField("zip_match", T.BooleanType(), True),
+    T.StructField("missing_street_in_output", T.BooleanType(), True),
+    T.StructField("street_present_but_house_missing", T.BooleanType(), True),
+    T.StructField("component_mismatch_count", T.IntegerType(), True),
+    T.StructField("is_city_level_match", T.BooleanType(), True),
+    T.StructField("is_partial_match", T.BooleanType(), True),
+    T.StructField("distance_km", T.DoubleType(), True),
+    T.StructField("is_far_distance", T.BooleanType(), True),
+    T.StructField("is_out_of_region", T.BooleanType(), True),
+    T.StructField("region_match", T.BooleanType(), True),
+    T.StructField("confidence_score", T.DoubleType(), True),
+    T.StructField("is_low_confidence", T.BooleanType(), True),
+    T.StructField("is_suspicious", T.BooleanType(), True),
+])
+
+
+def normalize_text(value):
+    if value is None:
+        return ""
+    text = str(value).strip().lower()
+    text = re.sub(r"[^a-z0-9\s]", " ", text)
+    text = re.sub(r"\s+", " ", text)
+    return text.strip()
+
+
+def normalize_state(value):
+    text = normalize_text(value)
+    if not text:
+        return ""
+    if len(text) == 2:
+        return text.upper()
+    return STATE_ABBREVIATIONS.get(text, text.upper())
+
+
+def normalize_street(value):
+    text = normalize_text(value)
+    if not text:
+        return ""
+    return " ".join(STREET_SUFFIXES.get(token, token) for token in text.split())
+
+
+def extract_zip(value):
+    match = re.search(r"\b(\d{5})(?:-\d{4})?\b", str(value or ""))
+    return match.group(1) if match else None
+
+
+def extract_house_number(value):
+    match = re.match(r"^\s*(\d+[a-zA-Z\-]?)\b", str(value or ""))
+    return match.group(1) if match else None
+
+
+def tokenize_address(address):
+    parts = [part.strip() for part in str(address or "").split(",") if part.strip()]
+    street = parts[0] if len(parts) > 0 else ""
+    city = parts[1] if len(parts) > 1 else ""
+    state_zip = parts[2] if len(parts) > 2 else ""
+    country = parts[3] if len(parts) > 3 else ""
+    state = ""
+    postal_code = extract_zip(state_zip) or extract_zip(country)
+    tokens = state_zip.split()
+    if tokens:
+        state = normalize_state(tokens[0])
+    return street, city, state, postal_code or ""
+
+
+def haversine_km(lat1, lon1, lat2, lon2):
+    try:
+        lat1_f, lon1_f, lat2_f, lon2_f = map(float, [lat1, lon1, lat2, lon2])
+    except (TypeError, ValueError):
+        return None
+    radius_km = 6371.0088
+    dlat = math.radians(lat2_f - lat1_f)
+    dlon = math.radians(lon2_f - lon1_f)
+    a = (
+        math.sin(dlat / 2) ** 2
+        + math.cos(math.radians(lat1_f)) * math.cos(math.radians(lat2_f)) * math.sin(dlon / 2) ** 2
+    )
+    return 2 * radius_km * math.asin(math.sqrt(a))
+
+
+# =========================================================
+# 6. Validation UDF
+# =========================================================
+
+@F.udf(returnType=validation_schema)
+def validate_mapping_udf(
+    canonical_address,
+    street,
+    city,
+    state,
+    postal_code,
+    borough,
+    county,
+    formatted_address,
+    lat,
+    lng,
+    input_lat,
+    input_lng,
+):
+    input_street = street or ""
+    input_city = city or ""
+    input_state = state or ""
+    input_zip = postal_code or ""
+
+    if not input_street and canonical_address:
+        parsed_street, parsed_city, parsed_state, parsed_zip = tokenize_address(canonical_address)
+        input_street = input_street or parsed_street
+        input_city = input_city or parsed_city
+        input_state = input_state or parsed_state
+        input_zip = input_zip or parsed_zip
+
+    output_street, output_city, output_state, output_zip = tokenize_address(formatted_address)
+
+    normalized_input_address = normalize_text(" ".join(filter(None, [input_street, input_city, input_state, input_zip])))
+    normalized_formatted_address = normalize_text(formatted_address)
+    input_house_number = extract_house_number(input_street)
+    output_house_number = extract_house_number(output_street)
+    input_street_normalized = normalize_street(input_street)
+    output_street_normalized = normalize_street(output_street)
+    input_city_normalized = normalize_text(input_city)
+    output_city_normalized = normalize_text(output_city)
+    input_state_normalized = normalize_state(input_state)
+    output_state_normalized = normalize_state(output_state)
+    input_zip_normalized = extract_zip(input_zip)
+    output_zip_normalized = extract_zip(output_zip)
+
+    street_match = bool(input_street_normalized and output_street_normalized and input_street_normalized == output_street_normalized)
+    house_number_match = bool(input_house_number and output_house_number and input_house_number == output_house_number)
+    city_match = bool(input_city_normalized and output_city_normalized and input_city_normalized == output_city_normalized)
+    state_match = bool(input_state_normalized and output_state_normalized and input_state_normalized == output_state_normalized)
+    zip_match = bool(input_zip_normalized and output_zip_normalized and input_zip_normalized == output_zip_normalized)
+    missing_street_in_output = bool(input_street_normalized and not output_street_normalized)
+    street_present_but_house_missing = bool(input_house_number and not output_house_number)
+
+    component_mismatch_count = sum([
+        int(bool(input_street_normalized) and not street_match),
+        int(bool(input_city_normalized) and not city_match),
+        int(bool(input_state_normalized) and not state_match),
+        int(bool(input_zip_normalized) and not zip_match),
+    ])
+
+    output_looks_like_city_only = bool(
+        output_city_normalized and output_street_normalized and output_street_normalized == output_city_normalized and not output_house_number
+    )
+    is_city_level_match = bool((input_street_normalized or input_house_number) and ((not output_house_number and output_city_normalized) or output_looks_like_city_only))
+    is_partial_match = bool((input_street_normalized or input_house_number) and not is_city_level_match and output_street_normalized and input_house_number and not output_house_number)
+
+    distance_km = haversine_km(input_lat, input_lng, lat, lng)
+    is_far_distance = bool(distance_km is not None and distance_km > float(CONFIG["far_distance_threshold_km"]))
+
+    formatted_text = normalize_text(formatted_address)
+    locality_candidates = {
+        normalize_text(borough),
+        normalize_text(county),
+        formatted_text,
+        input_city_normalized,
+        output_city_normalized,
+    }
+    locality_hits = any(
+        locality and (
+            locality in ALLOWED_LOCALITIES
+            or locality in ALLOWED_COUNTIES
+            or any(allowed in locality for allowed in (ALLOWED_LOCALITIES | ALLOWED_COUNTIES))
+        )
+        for locality in locality_candidates
+    )
+
+    coords_in_bbox = False
+    try:
+        lat_f = float(lat)
+        lng_f = float(lng)
+        coords_in_bbox = (
+            ALLOWED_REGION_BBOX["min_lat"] <= lat_f <= ALLOWED_REGION_BBOX["max_lat"]
+            and ALLOWED_REGION_BBOX["min_lng"] <= lng_f <= ALLOWED_REGION_BBOX["max_lng"]
+        )
+    except (TypeError, ValueError):
+        coords_in_bbox = False
+
+    state_is_ny = bool(
+        output_state_normalized == "NY"
+        or re.search(r"\bny\b", formatted_text) is not None
+        or "new york" in formatted_text
+    )
+    is_out_of_region = bool((output_state_normalized and not state_is_ny) or (not locality_hits and not coords_in_bbox))
+    region_match = not is_out_of_region
+
+    score = 0.0
+    score += CONFIG["street_weight"] * (1.0 if street_match and house_number_match else 0.75 if street_match else 0.0)
+    score += CONFIG["city_weight"] * (1.0 if city_match else 0.0)
+    score += CONFIG["state_weight"] * (1.0 if state_match else 0.0)
+    score += CONFIG["zip_weight"] * (1.0 if zip_match else 0.0)
+    score += CONFIG["granularity_weight"] * (0.0 if is_city_level_match else 0.5 if is_partial_match else 1.0)
+
+    if distance_km is None:
+        distance_component = 0.5
+    elif distance_km <= CONFIG["distance_threshold_km"]:
+        distance_component = 1.0
+    elif distance_km <= CONFIG["far_distance_threshold_km"]:
+        distance_component = 0.5
+    else:
+        distance_component = 0.0
+    score += CONFIG["distance_weight"] * distance_component
+    score += CONFIG["region_weight"] * (1.0 if region_match else 0.0)
+    confidence_score = round(max(0.0, min(1.0, score)), 4)
+    is_low_confidence = confidence_score < CONFIG["low_confidence_threshold"]
+    is_suspicious = bool(
+        is_low_confidence
+        or is_city_level_match
+        or is_partial_match
+        or is_far_distance
+        or is_out_of_region
+        or component_mismatch_count >= 2
+    )
+
+    return (
+        normalized_input_address,
+        normalized_formatted_address,
+        input_house_number,
+        output_house_number,
+        input_street_normalized,
+        output_street_normalized,
+        input_city_normalized,
+        output_city_normalized,
+        input_state_normalized,
+        output_state_normalized,
+        input_zip_normalized,
+        output_zip_normalized,
+        street_match,
+        house_number_match,
+        city_match,
+        state_match,
+        zip_match,
+        missing_street_in_output,
+        street_present_but_house_missing,
+        component_mismatch_count,
+        is_city_level_match,
+        is_partial_match,
+        distance_km,
+        is_far_distance,
+        is_out_of_region,
+        region_match,
+        confidence_score,
+        is_low_confidence,
+        is_suspicious,
+    )
+
+
+# =========================================================
+# 7. Apply Validation Logic
+# =========================================================
+
+validated_df = (
+    input_df
+    .withColumn(
+        "validation",
+        validate_mapping_udf(
+            F.col("canonical_address"),
+            F.coalesce(F.col("street"), F.lit(None).cast("string")),
+            F.coalesce(F.col("city"), F.lit(None).cast("string")),
+            F.coalesce(F.col("state"), F.lit(None).cast("string")),
+            F.coalesce(F.col("zip"), F.col("postal_code"), F.lit(None).cast("string")),
+            F.coalesce(F.col("borough"), F.lit(None).cast("string")),
+            F.coalesce(F.col("county"), F.lit(None).cast("string")),
+            F.col("formatted_address"),
+            F.col("lat"),
+            F.col("lng"),
+            F.coalesce(F.col("input_lat"), F.col("expected_lat"), F.lit(None).cast("double")),
+            F.coalesce(F.col("input_lng"), F.col("input_lon"), F.col("expected_lng"), F.col("expected_lon"), F.lit(None).cast("double")),
+        )
+    )
+    .select("*", "validation.*")
+    .drop("validation")
+    .withColumn("validation_ts", F.current_timestamp())
+)
+
+
+# =========================================================
+# 8. Write Validation Delta Table
+# =========================================================
+
+(
+    validated_df
+    .repartition(CONFIG["num_output_partitions"])
+    .write
+    .format("delta")
+    .mode(CONFIG["write_mode"])
+    .option("overwriteSchema", "true")
+    .saveAsTable(CONFIG["validation_table"])
+)
+
+
+# =========================================================
+# 9. Build Summary Metrics
+# =========================================================
+
+summary_df = (
+    validated_df
+    .agg(
+        F.count(F.lit(1)).alias("record_count"),
+        (F.avg(F.when(F.col("confidence_score") >= 0.85, 1.0).otherwise(0.0)) * 100.0).alias("pct_high_confidence"),
+        (F.avg(F.when(F.col("is_low_confidence"), 1.0).otherwise(0.0)) * 100.0).alias("pct_low_confidence"),
+        (F.avg(F.when(F.col("is_suspicious"), 1.0).otherwise(0.0)) * 100.0).alias("pct_likely_incorrect"),
+        (F.avg(F.when(F.col("is_city_level_match"), 1.0).otherwise(0.0)) * 100.0).alias("pct_city_level_match"),
+        (F.avg(F.when(F.col("is_partial_match"), 1.0).otherwise(0.0)) * 100.0).alias("pct_partial_match"),
+        (F.avg(F.when(F.col("is_far_distance"), 1.0).otherwise(0.0)) * 100.0).alias("pct_far_distance"),
+        (F.avg(F.when(F.col("is_out_of_region"), 1.0).otherwise(0.0)) * 100.0).alias("pct_out_of_region"),
+    )
+    .select(
+        F.array(
+            F.struct(F.lit("record_count").alias("metric"), F.col("record_count").cast("double").alias("value")),
+            F.struct(F.lit("pct_high_confidence").alias("metric"), F.round(F.col("pct_high_confidence"), 2).alias("value")),
+            F.struct(F.lit("pct_low_confidence").alias("metric"), F.round(F.col("pct_low_confidence"), 2).alias("value")),
+            F.struct(F.lit("pct_likely_incorrect").alias("metric"), F.round(F.col("pct_likely_incorrect"), 2).alias("value")),
+            F.struct(F.lit("pct_city_level_match").alias("metric"), F.round(F.col("pct_city_level_match"), 2).alias("value")),
+            F.struct(F.lit("pct_partial_match").alias("metric"), F.round(F.col("pct_partial_match"), 2).alias("value")),
+            F.struct(F.lit("pct_far_distance").alias("metric"), F.round(F.col("pct_far_distance"), 2).alias("value")),
+            F.struct(F.lit("pct_out_of_region").alias("metric"), F.round(F.col("pct_out_of_region"), 2).alias("value")),
+        ).alias("metrics")
+    )
+    .select(F.explode("metrics").alias("metric_struct"))
+    .select(
+        F.col("metric_struct.metric").alias("metric"),
+        F.col("metric_struct.value").alias("value"),
+    )
+    .withColumn("validation_ts", F.current_timestamp())
+)
+
+
+# =========================================================
+# 10. Write Summary Delta Table
+# =========================================================
+
+(
+    summary_df
+    .write
+    .format("delta")
+    .mode(CONFIG["write_mode"])
+    .option("overwriteSchema", "true")
+    .saveAsTable(CONFIG["summary_table"])
+)
+
+
+# =========================================================
+# 11. Delta Optimization
+# =========================================================
+
+spark.sql(f"OPTIMIZE {CONFIG['validation_table']} ZORDER BY (canonical_address, place_id)")
+spark.sql(f"OPTIMIZE {CONFIG['summary_table']} ZORDER BY (metric)")
+spark.sql(f"VACUUM {CONFIG['validation_table']} RETAIN 168 HOURS")
+spark.sql(f"VACUUM {CONFIG['summary_table']} RETAIN 168 HOURS")
+
+
+# =========================================================
+# 12. Runtime Metrics Summary
+# =========================================================
+
+summary_rows = {row['metric']: row['value'] for row in summary_df.collect()}
+
+print("=== Places Mapping Validation Metrics ===")
+print(f"Record count: {summary_rows.get('record_count', 0)}")
+print(f"% High confidence: {summary_rows.get('pct_high_confidence', 0)}")
+print(f"% Low confidence: {summary_rows.get('pct_low_confidence', 0)}")
+print(f"% Likely incorrect: {summary_rows.get('pct_likely_incorrect', 0)}")
+print(f"% City-level match: {summary_rows.get('pct_city_level_match', 0)}")
+print(f"% Partial match: {summary_rows.get('pct_partial_match', 0)}")
+print(f"% Far distance: {summary_rows.get('pct_far_distance', 0)}")
+print(f"% Out of region: {summary_rows.get('pct_out_of_region', 0)}")

--- a/scripts/validate_places_mappings.py
+++ b/scripts/validate_places_mappings.py
@@ -1,0 +1,400 @@
+"""Validate Google Places address mapping outputs without external API calls.
+
+This module compares original input address components against Google Places
+mapping outputs (formatted address, lat/lng, place_id) and assigns validation
+flags plus a confidence score so suspicious mappings can be reviewed or filtered.
+
+Usage example:
+    python scripts/validate_places_mappings.py \
+        --input mappings.csv \
+        --output validated_mappings.csv
+
+The script is intentionally offline-only and does not call any external APIs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import re
+from dataclasses import dataclass
+from typing import Dict, Iterable, Optional, Tuple
+
+import pandas as pd
+
+
+DEFAULT_CONFIG: Dict[str, object] = {
+    "distance_threshold_km": 2.0,
+    "far_distance_threshold_km": 5.0,
+    "low_confidence_threshold": 0.55,
+    "street_weight": 0.35,
+    "city_weight": 0.20,
+    "state_weight": 0.15,
+    "zip_weight": 0.10,
+    "granularity_weight": 0.10,
+    "distance_weight": 0.10,
+}
+
+STATE_ABBREVIATIONS = {
+    "alabama": "AL", "alaska": "AK", "arizona": "AZ", "arkansas": "AR",
+    "california": "CA", "colorado": "CO", "connecticut": "CT", "delaware": "DE",
+    "florida": "FL", "georgia": "GA", "hawaii": "HI", "idaho": "ID",
+    "illinois": "IL", "indiana": "IN", "iowa": "IA", "kansas": "KS",
+    "kentucky": "KY", "louisiana": "LA", "maine": "ME", "maryland": "MD",
+    "massachusetts": "MA", "michigan": "MI", "minnesota": "MN", "mississippi": "MS",
+    "missouri": "MO", "montana": "MT", "nebraska": "NE", "nevada": "NV",
+    "new hampshire": "NH", "new jersey": "NJ", "new mexico": "NM", "new york": "NY",
+    "north carolina": "NC", "north dakota": "ND", "ohio": "OH", "oklahoma": "OK",
+    "oregon": "OR", "pennsylvania": "PA", "rhode island": "RI", "south carolina": "SC",
+    "south dakota": "SD", "tennessee": "TN", "texas": "TX", "utah": "UT",
+    "vermont": "VT", "virginia": "VA", "washington": "WA", "west virginia": "WV",
+    "wisconsin": "WI", "wyoming": "WY", "district of columbia": "DC",
+}
+
+STREET_SUFFIXES = {
+    "street": "st", "st": "st", "avenue": "ave", "ave": "ave", "road": "rd", "rd": "rd",
+    "boulevard": "blvd", "blvd": "blvd", "drive": "dr", "dr": "dr", "lane": "ln", "ln": "ln",
+    "court": "ct", "ct": "ct", "place": "pl", "pl": "pl", "terrace": "ter", "ter": "ter",
+    "parkway": "pkwy", "pkwy": "pkwy", "circle": "cir", "cir": "cir", "highway": "hwy", "hwy": "hwy",
+}
+
+
+@dataclass
+class AddressComponents:
+    raw: str
+    normalized: str
+    house_number: Optional[str]
+    street: Optional[str]
+    city: Optional[str]
+    state: Optional[str]
+    postal_code: Optional[str]
+
+
+def normalize_text(value: object) -> str:
+    """Lowercase and normalize whitespace/punctuation for text comparison."""
+    if value is None or (isinstance(value, float) and pd.isna(value)):
+        return ""
+    text = str(value).strip().lower()
+    text = re.sub(r"[^a-z0-9\s]", " ", text)
+    text = re.sub(r"\s+", " ", text)
+    return text.strip()
+
+
+def normalize_state(value: object) -> str:
+    text = normalize_text(value)
+    if not text:
+        return ""
+    if len(text) == 2:
+        return text.upper()
+    return STATE_ABBREVIATIONS.get(text, text.upper())
+
+
+def normalize_street(street: object) -> str:
+    text = normalize_text(street)
+    if not text:
+        return ""
+    parts = [STREET_SUFFIXES.get(token, token) for token in text.split()]
+    return " ".join(parts)
+
+
+def extract_zip(value: object) -> Optional[str]:
+    match = re.search(r"\b(\d{5})(?:-\d{4})?\b", str(value or ""))
+    return match.group(1) if match else None
+
+
+def extract_house_number(value: object) -> Optional[str]:
+    match = re.match(r"^\s*(\d+[a-zA-Z\-]?)\b", str(value or ""))
+    return match.group(1) if match else None
+
+
+def tokenize_address(formatted_address: object) -> Tuple[str, str, str, str]:
+    parts = [part.strip() for part in str(formatted_address or "").split(",") if part.strip()]
+    street = parts[0] if len(parts) > 0 else ""
+    city = parts[1] if len(parts) > 1 else ""
+    state_zip = parts[2] if len(parts) > 2 else ""
+    country = parts[3] if len(parts) > 3 else ""
+
+    state = ""
+    postal_code = extract_zip(state_zip) or extract_zip(country)
+    tokens = state_zip.split()
+    if tokens:
+        state = normalize_state(tokens[0])
+
+    return street, city, state, postal_code or ""
+
+
+def parse_address_components(row: pd.Series) -> Tuple[AddressComponents, AddressComponents]:
+    """Create comparable component objects for input and Google output addresses."""
+    input_street = row.get("street") or row.get("input_street") or row.get("address_line_1") or ""
+    input_city = row.get("city") or row.get("input_city") or ""
+    input_state = row.get("state") or row.get("input_state") or ""
+    input_zip = row.get("zip") or row.get("zipcode") or row.get("postal_code") or row.get("input_zip") or ""
+
+    if not input_street and row.get("canonical_address"):
+        street, city, state, postal_code = tokenize_address(row.get("canonical_address"))
+        input_street = input_street or street
+        input_city = input_city or city
+        input_state = input_state or state
+        input_zip = input_zip or postal_code
+
+    output_formatted = row.get("formatted_address") or row.get("google_formatted_address") or ""
+    output_street, output_city, output_state, output_zip = tokenize_address(output_formatted)
+
+    input_components = AddressComponents(
+        raw=" ".join(filter(None, [str(input_street), str(input_city), str(input_state), str(input_zip)])),
+        normalized=normalize_text(" ".join(filter(None, [input_street, input_city, input_state, input_zip]))),
+        house_number=extract_house_number(input_street),
+        street=normalize_street(input_street),
+        city=normalize_text(input_city),
+        state=normalize_state(input_state),
+        postal_code=extract_zip(input_zip) or None,
+    )
+    output_components = AddressComponents(
+        raw=str(output_formatted),
+        normalized=normalize_text(output_formatted),
+        house_number=extract_house_number(output_street),
+        street=normalize_street(output_street),
+        city=normalize_text(output_city),
+        state=normalize_state(output_state),
+        postal_code=extract_zip(output_zip) or None,
+    )
+    return input_components, output_components
+
+
+def compare_components(input_addr: AddressComponents, output_addr: AddressComponents) -> Dict[str, object]:
+    street_match = bool(input_addr.street and output_addr.street and input_addr.street == output_addr.street)
+    house_number_match = bool(
+        input_addr.house_number and output_addr.house_number and input_addr.house_number == output_addr.house_number
+    )
+    city_match = bool(input_addr.city and output_addr.city and input_addr.city == output_addr.city)
+    state_match = bool(input_addr.state and output_addr.state and input_addr.state == output_addr.state)
+    zip_match = bool(input_addr.postal_code and output_addr.postal_code and input_addr.postal_code == output_addr.postal_code)
+
+    missing_street_in_output = bool(input_addr.street and not output_addr.street)
+    street_present_but_house_missing = bool(input_addr.house_number and not output_addr.house_number)
+    component_mismatch_count = sum([
+        int(bool(input_addr.street) and not street_match),
+        int(bool(input_addr.city) and not city_match),
+        int(bool(input_addr.state) and not state_match),
+        int(bool(input_addr.postal_code) and not zip_match),
+    ])
+
+    return {
+        "street_match": street_match,
+        "house_number_match": house_number_match,
+        "city_match": city_match,
+        "state_match": state_match,
+        "zip_match": zip_match,
+        "missing_street_in_output": missing_street_in_output,
+        "street_present_but_house_missing": street_present_but_house_missing,
+        "component_mismatch_count": component_mismatch_count,
+    }
+
+
+def detect_granularity_mismatch(input_addr: AddressComponents, output_addr: AddressComponents) -> Dict[str, bool]:
+    input_has_street_level = bool(input_addr.street or input_addr.house_number)
+    output_has_street_level = bool(output_addr.house_number)
+    output_looks_like_city_only = bool(
+        output_addr.city
+        and output_addr.street
+        and output_addr.street == output_addr.city
+        and not output_addr.house_number
+    )
+    is_city_level_match = bool(
+        input_has_street_level
+        and (
+            (not output_has_street_level and output_addr.city)
+            or output_looks_like_city_only
+        )
+    )
+    is_partial_match = bool(
+        input_has_street_level
+        and not is_city_level_match
+        and bool(output_addr.street)
+        and input_addr.house_number
+        and not output_addr.house_number
+    )
+    return {
+        "is_city_level_match": is_city_level_match,
+        "is_partial_match": is_partial_match,
+    }
+
+
+def haversine_km(lat1: object, lon1: object, lat2: object, lon2: object) -> Optional[float]:
+    try:
+        lat1_f, lon1_f, lat2_f, lon2_f = map(float, [lat1, lon1, lat2, lon2])
+    except (TypeError, ValueError):
+        return None
+
+    radius_km = 6371.0088
+    dlat = math.radians(lat2_f - lat1_f)
+    dlon = math.radians(lon2_f - lon1_f)
+    a = (
+        math.sin(dlat / 2) ** 2
+        + math.cos(math.radians(lat1_f))
+        * math.cos(math.radians(lat2_f))
+        * math.sin(dlon / 2) ** 2
+    )
+    return 2 * radius_km * math.asin(math.sqrt(a))
+
+
+def distance_validation(row: pd.Series, config: Dict[str, object]) -> Dict[str, object]:
+    expected_lat = row.get("input_lat") or row.get("expected_lat")
+    expected_lng = row.get("input_lng") or row.get("input_lon") or row.get("expected_lng") or row.get("expected_lon")
+    returned_lat = row.get("lat")
+    returned_lng = row.get("lng")
+
+    distance_km = haversine_km(expected_lat, expected_lng, returned_lat, returned_lng)
+    is_far_distance = bool(distance_km is not None and distance_km > float(config["far_distance_threshold_km"]))
+    return {
+        "distance_km": distance_km,
+        "is_far_distance": is_far_distance,
+    }
+
+
+def score_mapping(
+    component_results: Dict[str, object],
+    granularity_results: Dict[str, bool],
+    distance_results: Dict[str, object],
+    config: Dict[str, object],
+) -> float:
+    score = 0.0
+    score += float(config["street_weight"]) * (
+        1.0 if component_results["street_match"] and component_results["house_number_match"]
+        else 0.75 if component_results["street_match"]
+        else 0.0
+    )
+    score += float(config["city_weight"]) * (1.0 if component_results["city_match"] else 0.0)
+    score += float(config["state_weight"]) * (1.0 if component_results["state_match"] else 0.0)
+    score += float(config["zip_weight"]) * (1.0 if component_results["zip_match"] else 0.0)
+    score += float(config["granularity_weight"]) * (
+        0.0 if granularity_results["is_city_level_match"] else 0.5 if granularity_results["is_partial_match"] else 1.0
+    )
+
+    distance_km = distance_results["distance_km"]
+    if distance_km is None:
+        distance_component = 0.5
+    elif distance_km <= float(config["distance_threshold_km"]):
+        distance_component = 1.0
+    elif distance_km <= float(config["far_distance_threshold_km"]):
+        distance_component = 0.5
+    else:
+        distance_component = 0.0
+    score += float(config["distance_weight"]) * distance_component
+
+    return round(max(0.0, min(1.0, score)), 4)
+
+
+def validate_mapping_row(row: pd.Series, config: Dict[str, object]) -> pd.Series:
+    input_addr, output_addr = parse_address_components(row)
+    component_results = compare_components(input_addr, output_addr)
+    granularity_results = detect_granularity_mismatch(input_addr, output_addr)
+    distance_results = distance_validation(row, config)
+    confidence_score = score_mapping(component_results, granularity_results, distance_results, config)
+    is_low_confidence = confidence_score < float(config["low_confidence_threshold"])
+
+    result = {
+        "normalized_input_address": input_addr.normalized,
+        "normalized_formatted_address": output_addr.normalized,
+        "input_house_number": input_addr.house_number,
+        "output_house_number": output_addr.house_number,
+        "input_street_normalized": input_addr.street,
+        "output_street_normalized": output_addr.street,
+        "input_city_normalized": input_addr.city,
+        "output_city_normalized": output_addr.city,
+        "input_state_normalized": input_addr.state,
+        "output_state_normalized": output_addr.state,
+        "input_zip_normalized": input_addr.postal_code,
+        "output_zip_normalized": output_addr.postal_code,
+        **component_results,
+        **granularity_results,
+        **distance_results,
+        "confidence_score": confidence_score,
+        "is_low_confidence": is_low_confidence,
+        "is_suspicious": bool(
+            is_low_confidence
+            or granularity_results["is_city_level_match"]
+            or granularity_results["is_partial_match"]
+            or distance_results["is_far_distance"]
+            or component_results["component_mismatch_count"] >= 2
+        ),
+    }
+    return pd.Series(result)
+
+
+def validate_mappings(df: pd.DataFrame, config: Optional[Dict[str, object]] = None) -> pd.DataFrame:
+    config = {**DEFAULT_CONFIG, **(config or {})}
+    validation_df = df.apply(lambda row: validate_mapping_row(row, config), axis=1)
+    return pd.concat([df, validation_df], axis=1)
+
+
+def summarize_validation(validated_df: pd.DataFrame, config: Optional[Dict[str, object]] = None) -> pd.DataFrame:
+    config = {**DEFAULT_CONFIG, **(config or {})}
+    total = len(validated_df)
+    if total == 0:
+        return pd.DataFrame([
+            {"metric": "record_count", "value": 0}
+        ])
+
+    summary = [
+        {"metric": "record_count", "value": total},
+        {"metric": "pct_high_confidence", "value": round((validated_df["confidence_score"] >= 0.85).mean() * 100, 2)},
+        {"metric": "pct_low_confidence", "value": round((validated_df["confidence_score"] < float(config["low_confidence_threshold"])) .mean() * 100, 2)},
+        {"metric": "pct_likely_incorrect", "value": round(validated_df["is_suspicious"].mean() * 100, 2)},
+        {"metric": "pct_city_level_match", "value": round(validated_df["is_city_level_match"].mean() * 100, 2)},
+        {"metric": "pct_partial_match", "value": round(validated_df["is_partial_match"].mean() * 100, 2)},
+        {"metric": "pct_far_distance", "value": round(validated_df["is_far_distance"].fillna(False).mean() * 100, 2)},
+    ]
+    return pd.DataFrame(summary)
+
+
+def read_input_dataset(path: str) -> pd.DataFrame:
+    if path.endswith(".parquet"):
+        return pd.read_parquet(path)
+    if path.endswith(".json"):
+        return pd.read_json(path, lines=True)
+    return pd.read_csv(path)
+
+
+def write_output_dataset(df: pd.DataFrame, path: str) -> None:
+    if path.endswith(".parquet"):
+        df.to_parquet(path, index=False)
+    elif path.endswith(".json"):
+        df.to_json(path, orient="records", lines=True)
+    else:
+        df.to_csv(path, index=False)
+
+
+def parse_args(argv: Optional[Iterable[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate Google Places mapping outputs without API calls.")
+    parser.add_argument("--input", required=True, help="Input dataset path (.csv, .json, .parquet).")
+    parser.add_argument("--output", required=True, help="Validated output dataset path (.csv, .json, .parquet).")
+    parser.add_argument("--summary-output", help="Optional summary output path (.csv, .json, .parquet).")
+    parser.add_argument("--distance-threshold-km", type=float, default=DEFAULT_CONFIG["distance_threshold_km"])
+    parser.add_argument("--far-distance-threshold-km", type=float, default=DEFAULT_CONFIG["far_distance_threshold_km"])
+    parser.add_argument("--low-confidence-threshold", type=float, default=DEFAULT_CONFIG["low_confidence_threshold"])
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[Iterable[str]] = None) -> None:
+    args = parse_args(argv)
+    config = {
+        "distance_threshold_km": args.distance_threshold_km,
+        "far_distance_threshold_km": args.far_distance_threshold_km,
+        "low_confidence_threshold": args.low_confidence_threshold,
+    }
+
+    df = read_input_dataset(args.input)
+    validated_df = validate_mappings(df, config)
+    summary_df = summarize_validation(validated_df, config)
+
+    write_output_dataset(validated_df, args.output)
+    if args.summary_output:
+        write_output_dataset(summary_df, args.summary_output)
+
+    print("=== Mapping Validation Summary ===")
+    print(summary_df.to_string(index=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_places_mappings.py
+++ b/scripts/validate_places_mappings.py
@@ -33,6 +33,63 @@ DEFAULT_CONFIG: Dict[str, object] = {
     "zip_weight": 0.10,
     "granularity_weight": 0.10,
     "distance_weight": 0.10,
+    "region_weight": 0.10,
+}
+
+ALLOWED_LOCALITIES = {
+    "manhattan",
+    "new york",
+    "brooklyn",
+    "queens",
+    "bronx",
+    "staten island",
+    "yonkers",
+    "mount vernon",
+    "new rochelle",
+    "white plains",
+    "peekskill",
+    "rye",
+    "harrison",
+    "mamaroneck",
+    "larchmont",
+    "tarrytown",
+    "sleepy hollow",
+    "ossining",
+    "dobbs ferry",
+    "irvington",
+    "hastings on hudson",
+    "scarsdale",
+    "greenburgh",
+    "eastchester",
+    "pelham",
+    "bronxville",
+    "ardsley",
+    "elmsford",
+    "pleasantville",
+    "briarcliff manor",
+    "bedford",
+    "mount kisco",
+    "chappaqua",
+    "cortlandt",
+    "croton on hudson",
+    "pleasantville",
+    "port chester",
+}
+
+ALLOWED_COUNTIES = {
+    "new york county",
+    "kings county",
+    "queens county",
+    "bronx county",
+    "richmond county",
+    "westchester county",
+}
+
+ALLOWED_REGION_BBOX = {
+    "min_lat": 40.49,
+    "max_lat": 41.35,
+    "min_lng": -74.35,
+    "max_lng": -73.45,
 }
 
 STATE_ABBREVIATIONS = {
@@ -252,10 +309,55 @@ def distance_validation(row: pd.Series, config: Dict[str, object]) -> Dict[str, 
     }
 
 
+def region_validation(row: pd.Series, input_addr: AddressComponents, output_addr: AddressComponents) -> Dict[str, object]:
+    """Flag mappings that fall outside NYC boroughs or Westchester County."""
+    formatted_text = normalize_text(row.get("formatted_address") or row.get("google_formatted_address"))
+    locality_candidates = {
+        normalize_text(row.get("borough")),
+        normalize_text(row.get("county")),
+        formatted_text,
+        input_addr.city,
+        output_addr.city,
+    }
+    locality_hits = any(
+        locality and (
+            locality in ALLOWED_LOCALITIES
+            or locality in ALLOWED_COUNTIES
+            or any(allowed in locality for allowed in ALLOWED_LOCALITIES | ALLOWED_COUNTIES)
+        )
+        for locality in locality_candidates
+    )
+
+    returned_lat = row.get("lat")
+    returned_lng = row.get("lng")
+    coords_in_bbox = False
+    try:
+        lat = float(returned_lat)
+        lng = float(returned_lng)
+        coords_in_bbox = (
+            ALLOWED_REGION_BBOX["min_lat"] <= lat <= ALLOWED_REGION_BBOX["max_lat"]
+            and ALLOWED_REGION_BBOX["min_lng"] <= lng <= ALLOWED_REGION_BBOX["max_lng"]
+        )
+    except (TypeError, ValueError):
+        coords_in_bbox = False
+
+    state_is_ny = bool(
+        output_addr.state == "NY"
+        or re.search(r"\bny\b", formatted_text) is not None
+        or "new york" in formatted_text
+    )
+    is_out_of_region = bool((output_addr.state and not state_is_ny) or (not locality_hits and not coords_in_bbox))
+    return {
+        "is_out_of_region": is_out_of_region,
+        "region_match": not is_out_of_region,
+    }
+
+
 def score_mapping(
     component_results: Dict[str, object],
     granularity_results: Dict[str, bool],
     distance_results: Dict[str, object],
+    region_results: Dict[str, object],
     config: Dict[str, object],
 ) -> float:
     score = 0.0
@@ -281,6 +383,7 @@ def score_mapping(
     else:
         distance_component = 0.0
     score += float(config["distance_weight"]) * distance_component
+    score += float(config["region_weight"]) * (1.0 if region_results["region_match"] else 0.0)
 
     return round(max(0.0, min(1.0, score)), 4)
 
@@ -290,7 +393,8 @@ def validate_mapping_row(row: pd.Series, config: Dict[str, object]) -> pd.Series
     component_results = compare_components(input_addr, output_addr)
     granularity_results = detect_granularity_mismatch(input_addr, output_addr)
     distance_results = distance_validation(row, config)
-    confidence_score = score_mapping(component_results, granularity_results, distance_results, config)
+    region_results = region_validation(row, input_addr, output_addr)
+    confidence_score = score_mapping(component_results, granularity_results, distance_results, region_results, config)
     is_low_confidence = confidence_score < float(config["low_confidence_threshold"])
 
     result = {
@@ -309,6 +413,7 @@ def validate_mapping_row(row: pd.Series, config: Dict[str, object]) -> pd.Series
         **component_results,
         **granularity_results,
         **distance_results,
+        **region_results,
         "confidence_score": confidence_score,
         "is_low_confidence": is_low_confidence,
         "is_suspicious": bool(
@@ -316,6 +421,7 @@ def validate_mapping_row(row: pd.Series, config: Dict[str, object]) -> pd.Series
             or granularity_results["is_city_level_match"]
             or granularity_results["is_partial_match"]
             or distance_results["is_far_distance"]
+            or region_results["is_out_of_region"]
             or component_results["component_mismatch_count"] >= 2
         ),
     }
@@ -344,6 +450,7 @@ def summarize_validation(validated_df: pd.DataFrame, config: Optional[Dict[str, 
         {"metric": "pct_city_level_match", "value": round(validated_df["is_city_level_match"].mean() * 100, 2)},
         {"metric": "pct_partial_match", "value": round(validated_df["is_partial_match"].mean() * 100, 2)},
         {"metric": "pct_far_distance", "value": round(validated_df["is_far_distance"].fillna(False).mean() * 100, 2)},
+        {"metric": "pct_out_of_region", "value": round(validated_df["is_out_of_region"].fillna(False).mean() * 100, 2)},
     ]
     return pd.DataFrame(summary)
 


### PR DESCRIPTION
### Motivation
- Switch the Fabric geocoding layer to use Google Places API (Legacy) `findplacefromtext` with minimal fields to control field-based billing and provide a controlled fallback for place details. 
- Provide an offline validation tool to score and flag suspicious mappings without making API calls so mapping quality can be reviewed before promotion. 
- Persist geocoding results, failures, and enriched outputs into Delta tables to support incremental runs and pipeline observability. 

### Description
- Added `fabric_geocode_pipeline_notebook.py`, a Spark-friendly, partitioned geocoding job that uses `PLACES_FIND_PLACE_URL` (`findplacefromtext`) with `fields=place_id,formatted_address,geometry,name`, optional details fallback behind `enable_place_details_fallback`, partition-local rate limiting, thread-pool concurrency, retry/backoff, cache MERGE into `SLI_Silver.address_geocode_cache`, dead-letter table `SLI_Silver.address_geocode_failures`, and writes enriched results to `SLI_Gold.address_geocode_enriched` with `OPTIMIZE`/`ZORDER`/`VACUUM` steps. 
- Added `scripts/validate_places_mappings.py`, an offline-only validator that parses input vs returned addresses, normalizes components, computes component/granularity/distance checks, and produces per-record flags plus a `confidence_score` and a summary output; it supports `.csv`, `.json`, and `.parquet` I/O and a small CLI. 
- Updated `README.md` to document the Fabric geocoding notebook switch to Google Places (Legacy), describe the `enable_place_details_fallback` flag, point to the offline validation script `scripts/validate_places_mappings.py`, and include reference links and billing notes. 

### Testing
- Performed static syntax checks using `python -m py_compile scripts/validate_places_mappings.py` and `python -m py_compile fabric_geocode_pipeline_notebook.py`, and both checks succeeded. 
- No automated unit tests or CI test suite were added in this change. 
- The validation script includes a CLI and was exercised locally for argument parsing via `--help` to verify basic runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b18ac149348324a624144cd1801caa)